### PR TITLE
Add multi-select support for domino tiles

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -263,6 +263,12 @@ button.secondary:hover {
   transform: translateY(-1px);
 }
 
+.tile-selector-preview {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
 .tile-clear {
   border: none;
   background: rgba(239, 68, 68, 0.1);
@@ -332,6 +338,12 @@ button.secondary:hover {
 .round-points {
   font-weight: 700;
   color: #1d4ed8;
+}
+
+.round-cell-tiles {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .round-cell-tile {
@@ -455,6 +467,67 @@ button.secondary:hover {
   gap: 1rem;
   overflow-y: auto;
   padding-right: 0.35rem;
+}
+
+.tile-picker-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.tile-picker-count {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.tile-picker-buttons {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.tile-picker-action-clear,
+.tile-picker-action-confirm {
+  border-radius: 12px;
+  padding: 0.55rem 1.1rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.tile-picker-action-clear {
+  background: rgba(239, 68, 68, 0.08);
+  color: #b91c1c;
+  border-color: rgba(239, 68, 68, 0.35);
+}
+
+.tile-picker-action-clear:hover:not(:disabled) {
+  background: rgba(239, 68, 68, 0.16);
+  transform: translateY(-1px);
+}
+
+.tile-picker-action-clear:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.tile-picker-action-confirm {
+  background: #2563eb;
+  color: #ffffff;
+  border-color: #2563eb;
+  box-shadow: 0 10px 18px rgba(37, 99, 235, 0.28);
+}
+
+.tile-picker-action-confirm:hover {
+  background: #1d4ed8;
+  border-color: #1d4ed8;
+  transform: translateY(-1px);
 }
 
 .tile-picker-item {


### PR DESCRIPTION
## Summary
- allow storing multiple domino tiles per player when recording a round
- update the round form and history table to preview and list all selected tiles
- redesign the tile picker for toggling multiple tiles with clear and confirm actions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da6dcafb548329ab3ecf2757f62995