### PR TITLE
Add multi-step wizard to domino scoreboard

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -28,6 +28,93 @@
   line-height: 1.6;
 }
 
+.wizard-steps {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin-bottom: 2.5rem;
+}
+
+.wizard-step {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.85rem;
+  border-radius: 16px;
+  border: 1px solid rgba(37, 99, 235, 0.18);
+  background: rgba(59, 130, 246, 0.06);
+  padding: 1rem 1.1rem;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.wizard-step:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.wizard-step:not(:disabled):hover {
+  border-color: rgba(37, 99, 235, 0.45);
+  box-shadow: 0 14px 24px rgba(37, 99, 235, 0.16);
+  transform: translateY(-1px);
+}
+
+.wizard-step-active {
+  border-color: rgba(79, 70, 229, 0.7);
+  background: linear-gradient(135deg, rgba(79, 70, 229, 0.12), rgba(37, 99, 235, 0.12));
+  box-shadow: 0 16px 26px rgba(79, 70, 229, 0.18);
+}
+
+.wizard-step-completed {
+  border-color: rgba(16, 185, 129, 0.7);
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.12), rgba(59, 130, 246, 0.08));
+}
+
+.wizard-step-index {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: white;
+  color: #2563eb;
+  font-weight: 700;
+  font-size: 1.05rem;
+  flex-shrink: 0;
+  box-shadow: 0 4px 10px rgba(37, 99, 235, 0.2);
+}
+
+.wizard-step-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.wizard-step-title {
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.wizard-step-description {
+  color: #4b5563;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.wizard-content {
+  margin-bottom: 2.5rem;
+}
+
+.wizard-navigation {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 3rem;
+}
+
 .section-header {
   display: flex;
   flex-direction: column;
@@ -230,6 +317,17 @@ button.secondary:hover {
   font-size: 1rem;
 }
 
+.tile-sum {
+  display: inline-block;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(16, 185, 129, 0.12);
+  color: #047857;
+  font-weight: 600;
+  font-size: 0.95rem;
+  align-self: flex-start;
+}
+
 .round-label input:focus {
   outline: none;
   border-color: rgba(59, 130, 246, 0.7);
@@ -290,6 +388,80 @@ button.secondary:hover {
 .round-error {
   margin: 0 0 1rem;
   color: #b91c1c;
+  font-weight: 600;
+}
+
+.tournament-progress {
+  margin-bottom: 2.5rem;
+}
+
+.progress-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.25rem;
+}
+
+.progress-card {
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(255, 255, 255, 0.9);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.5);
+}
+
+.progress-card-finished {
+  border-color: rgba(239, 68, 68, 0.65);
+  box-shadow: 0 12px 20px rgba(239, 68, 68, 0.2);
+}
+
+.progress-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.progress-player-name {
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.progress-total {
+  font-weight: 600;
+  color: #2563eb;
+}
+
+.progress-bar {
+  position: relative;
+  width: 100%;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.35);
+  overflow: hidden;
+}
+
+.progress-bar-fill {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, #2563eb, #7c3aed);
+  border-radius: 999px;
+}
+
+.progress-details {
+  font-size: 0.95rem;
+  color: #4b5563;
+}
+
+.progress-footnote {
+  margin-top: 1.5rem;
+  padding: 1rem 1.25rem;
+  border-radius: 14px;
+  background: rgba(59, 130, 246, 0.08);
+  border: 1px dashed rgba(59, 130, 246, 0.35);
+  color: #1f2937;
   font-weight: 600;
 }
 
@@ -633,5 +805,10 @@ button.secondary:hover {
   .round-table th,
   .round-table td {
     padding: 0.75rem;
+  }
+
+  .wizard-navigation {
+    flex-direction: column;
+    align-items: stretch;
   }
 }


### PR DESCRIPTION
## Summary
- add a four-step wizard experience to configure players, run rounds, review progress, and show final results
- surface domino tile point totals during round entry and display tournament progress until a player reaches the target
- refresh styling to support the wizard navigation, progress cards, and responsive layout adjustments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da921e18b0832995c694c8e7d133e2