### PR TITLE
Fix round point totals combining manual and tile contributions

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -321,6 +321,13 @@ button.secondary:hover {
   font-size: 1rem;
 }
 
+.round-points-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  align-items: flex-start;
+}
+
 .tile-sum {
   display: inline-block;
   padding: 0.4rem 0.75rem;
@@ -329,7 +336,16 @@ button.secondary:hover {
   color: #047857;
   font-weight: 600;
   font-size: 0.95rem;
-  align-self: flex-start;
+}
+
+.round-total-points {
+  display: inline-block;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+  font-weight: 600;
+  font-size: 0.95rem;
 }
 
 .round-label input:focus {

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -264,12 +264,11 @@ function App() {
       const tileIds = draftEntry?.tileIds ?? []
       const rawPoints = draftEntry?.points ?? ''
       const parsed = Number.parseInt(rawPoints, 10)
-      const hasManualPoints = rawPoints.length > 0 && !Number.isNaN(parsed)
       const manualPoints = Number.isNaN(parsed) ? 0 : Math.max(parsed, 0)
       const tilePoints = calculateTilePoints(tileIds)
-      const points = hasManualPoints ? manualPoints : tilePoints
+      const points = manualPoints + tilePoints
 
-      if (points > 0 || tileIds.length > 0) {
+      if (manualPoints > 0 || tilePoints > 0 || tileIds.length > 0) {
         hasData = true
       }
 
@@ -436,6 +435,9 @@ function App() {
                 .map((tileId) => DOMINO_TILE_MAP.get(tileId))
                 .filter((tile): tile is DominoTile => Boolean(tile))
               const tilePoints = calculateTilePoints(draftEntry?.tileIds ?? [])
+              const manualPoints = Number.parseInt(draftEntry?.points ?? '', 10)
+              const safeManualPoints = Number.isNaN(manualPoints) ? 0 : manualPoints
+              const totalRoundPoints = safeManualPoints + tilePoints
 
               return (
                 <div key={player.id} className="round-input">
@@ -493,7 +495,10 @@ function App() {
                         </button>
                       ) : null}
                     </div>
-                    <span className="tile-sum">Сумма по фишкам: {tilePoints}</span>
+                    <div className="round-points-summary">
+                      <span className="tile-sum">Очки за фишки: {tilePoints}</span>
+                      <span className="round-total-points">Итого за раунд: {totalRoundPoints}</span>
+                    </div>
                   </div>
                 </div>
               )


### PR DESCRIPTION
## Summary
- ensure manual points entered in the round form are added to the automatic tile score when saving a round
- surface the combined round total next to the tile sum so players can see how many points will be recorded

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da9703bfe48329a191ec357884426c