### PR TITLE
Remove manual score entry field

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -306,21 +306,6 @@ button.secondary:hover {
   gap: 0.85rem;
 }
 
-.round-label {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  font-weight: 600;
-  color: #374151;
-}
-
-.round-label input {
-  border: 1px solid rgba(17, 24, 39, 0.2);
-  border-radius: 12px;
-  padding: 0.6rem 0.75rem;
-  font-size: 1rem;
-}
-
 .round-points-summary {
   display: flex;
   flex-direction: column;
@@ -346,12 +331,6 @@ button.secondary:hover {
   color: #1d4ed8;
   font-weight: 600;
   font-size: 0.95rem;
-}
-
-.round-label input:focus {
-  outline: none;
-  border-color: rgba(59, 130, 246, 0.7);
-  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.12);
 }
 
 .tile-selector {


### PR DESCRIPTION
## Summary
- remove the manual score input from round creation and compute points solely from selected tiles
- update wizard messaging to reflect automatic scoring and drop unused styling for the old field

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dab4f217748329992fdbb5deee9941