### PR TITLE
Prevent selecting already used tiles in a round

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -289,6 +289,24 @@ function App() {
   const activePickerPlayer = activePicker
     ? players.find((player) => player.id === activePicker)
     : undefined
+  const activePickerExcludedTileIds = useMemo(() => {
+    if (!activePicker) {
+      return []
+    }
+
+    const excluded = new Set<string>()
+
+    players.forEach((player) => {
+      if (player.id === activePicker) {
+        return
+      }
+
+      const tileIds = roundDraft[player.id]?.tileIds ?? []
+      tileIds.forEach((tileId) => excluded.add(tileId))
+    })
+
+    return Array.from(excluded)
+  }, [activePicker, players, roundDraft])
 
   const handlePreviousStep = () => {
     setCurrentStep((prev) => Math.max(1, prev - 1))
@@ -739,6 +757,7 @@ function App() {
         }}
         selectedTileIds={activePicker ? roundDraft[activePicker]?.tileIds ?? [] : []}
         playerName={activePickerPlayer?.name}
+        excludedTileIds={activePickerExcludedTileIds}
       />
     </div>
   )


### PR DESCRIPTION
## Summary
- compute the domino tiles taken by other players in the current round and expose them to the picker
- filter the tile picker options to hide tiles that were already chosen and block toggling them

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dabb1410b88329b4f7740fd2d7201d