### PR TITLE
Prevent saving rounds after target score reached

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -236,6 +236,10 @@ function App() {
   }
 
   const handleAddRound = () => {
+    if (isTournamentFinished) {
+      return
+    }
+
     if (players.length === 0) {
       return
     }
@@ -451,9 +455,19 @@ function App() {
             })}
           </div>
           {roundError ? <p className="round-error">{roundError}</p> : null}
-          <button type="button" className="primary" onClick={handleAddRound}>
-            Сохранить раунд
-          </button>
+          {isTournamentFinished ? (
+            <button
+              type="button"
+              className="primary"
+              onClick={() => setCurrentStep(4)}
+            >
+              Перейти к результатам
+            </button>
+          ) : (
+            <button type="button" className="primary" onClick={handleAddRound}>
+              Сохранить раунд
+            </button>
+          )}
         </section>
       )
     }


### PR DESCRIPTION
## Summary
- prevent adding additional rounds once the tournament target score has been reached
- replace the round save button with a shortcut to the results view after the finish condition is met

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68daf09a53f48329a98232c182dec755